### PR TITLE
chore(ci): pin cicd-workflows reusable workflows to commit SHA

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -19,6 +19,6 @@ on:
     types: [checks_requested]
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     with:
       bazel-target: "run //:copyright.check"

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -24,6 +24,6 @@ on:
 
 jobs:
   docs-cleanup:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   build-docs:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,6 @@ on:
 
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     with:
       bazel-target: "test //:format.check" # optional, this is the default

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   license-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     with:
       repo-url: "${{ github.server_url }}/${{ github.repository }}"
     secrets:


### PR DESCRIPTION
This PR is part of a large-scale CI refactoring across all S-CORE repositories.

See the tracking issue:
https://github.com/eclipse-score/cicd-workflows/issues/75

It updates reusable workflow references from `eclipse-score/cicd-workflows`
to the pinned commit SHA (tagged as `v0.0.0`):

`c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0`

Only the `@ref` part of workflow calls is changed, for workflows under:

`eclipse-score/cicd-workflows/.github/workflows/*`

Pinning reusable workflows to a commit SHA ensures stable and reproducible CI
behavior instead of relying on a moving branch reference.

Part of eclipse-score/cicd-workflows#75
