### PR TITLE
chore(bazel): make module declarations one line

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,11 +10,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-module(
-    name = "score_inc_daal",
-    version = "0.0.1",
-    compatibility_level = 0,
-)
+module(name = "score_inc_daal")
 
 bazel_dep(name = "rules_python", version = "1.4.1")
 


### PR DESCRIPTION
<!-- repo-sync-policy: bazel.module-one-line -->

## Policy

**`bazel.module-one-line`**

Keep the Bazel module declaration compact and consistent.

## Why this repository?

This repository contains policy-managed legacy content in `MODULE.bazel`.

## Changes

- `MODULE.bazel`: replace matching text
  - Do not hardcode the module version in Git; the Bazel Registry derives it dynamically when a Git release of the module is made, and `compatibility_level` is deprecated.

---

This pull request is managed by `repo-sync` and may be updated by a later policy run.  
Please report any issues to [#score-infrastructure](https://sdvworkinggroup.slack.com/archives/C0894QGRZDM).

> [!WARNING]
> The tool producing this PR is in proof-of-concept stage. Review carefully.
